### PR TITLE
FIX: Expected Outcome bug fixed

### DIFF
--- a/src/Components/ProjectsComponent/PayloadComponents/components/AddExpOutcomeForm.jsx
+++ b/src/Components/ProjectsComponent/PayloadComponents/components/AddExpOutcomeForm.jsx
@@ -8,7 +8,7 @@ import ExpectedOutcomeTable from 'Components/ProjectsComponent/ExpectedOutcomeTa
 import { EXPECTED_OUTCOME_TEMPLATE } from 'constants/appConstants';
 
 const AddExpOutcomeForm = ({ onSave, onClose }) => {
-    const [formData, setFormData] = useState(EXPECTED_OUTCOME_TEMPLATE);
+    const [formData, setFormData] = useState({ name: "", expected_outcome: [EXPECTED_OUTCOME_TEMPLATE] });
 
     const handleChange = (name, value) => {
         setFormData(p => ({
@@ -29,7 +29,7 @@ const AddExpOutcomeForm = ({ onSave, onClose }) => {
                 <FormInput 
                     label={'Name'}
                     name='name'
-                    value={formData.title}
+                    value={formData.name}
                     onChange={e => handleChange(e.target.name, e.target.value)}
                     placeholder='Name'
                     isRequired
@@ -53,6 +53,7 @@ const AddExpOutcomeForm = ({ onSave, onClose }) => {
                         size={'sm'}
                         handleClick={handleSubmit}
                         type="button"
+                        disabled={formData.name.length===0}
                     />
                 </div>
             </Form>

--- a/src/constants/appConstants.js
+++ b/src/constants/appConstants.js
@@ -13,15 +13,10 @@ export const BOOLEAN_SELECT_OPTION = [
 ]
 
 export const EXPECTED_OUTCOME_TEMPLATE = {
-    name: "",
-    expected_outcome: [
-        {
-            name: "status_code",
-            type: "number",
-            isExact: true,
-            value: 200
-        }
-    ]
+    name: "status_code",
+    type: "number",
+    isExact: true,
+    value: 200
 }
 
 export const SELECT_OPTIONS_TESTDATA_FORM = {


### PR DESCRIPTION
The initial value of the status code of the expected outcome in payload form must be 200, but after saving one expected outcome by changing the status_code value the template value is also changed.

Before:
![Screenshot from 2022-10-10 11-57-18](https://user-images.githubusercontent.com/72058456/194809138-fb955c44-9062-4fa8-8f95-27e7529e30b8.png)

After:
![Screenshot from 2022-10-10 12-02-16](https://user-images.githubusercontent.com/72058456/194809282-9bd9661d-3599-4bff-87d5-1dd7e9214e85.png)


