### PR TITLE
UPD: Initial Testdata updated when new testdata form submitted

### DIFF
--- a/src/containers/ProjectContainer/TeststepContainer/index.jsx
+++ b/src/containers/ProjectContainer/TeststepContainer/index.jsx
@@ -56,7 +56,7 @@ const TeststepContainer = (props) => {
     }, [projectName]);
 
     useEffect(() => {
-        setSelectedItem(teststeps.filter(e => e.id == id)[0]);
+        setSelectedItem(teststeps.filter(e => e.id == id)[0] || {});
         dispatch(getTestdataRequest({ teststep: id }));
     }, [teststeps, id]);
 
@@ -103,26 +103,47 @@ const TeststepContainer = (props) => {
     };
 
     const setInitialTestdata = () => {
+        const { id: teststepId, payload } = selectedItem;
+        const {
+            expected_outcome: initialTDExpOutcome,
+            name: initialTDName,
+            parameters: initialTDParams,
+            payload: initialTDPayload,
+            selected_expected_outcome: initialTDSelectedExpOutcome,
+            teststep: initialTDId,
+        } = INITIAL_TESTDATA_FORM_DATA;
+
         setTestdataFormData(p => ({
             ...p,
-            name: INITIAL_TESTDATA_FORM_DATA.name,
-            teststep: selectedItem?.id || INITIAL_TESTDATA_FORM_DATA.teststep,
-            payload: JSON.stringify(selectedItem?.payload?.payload || INITIAL_TESTDATA_FORM_DATA.payload),
-            parameters: selectedItem?.payload?.parameters || INITIAL_TESTDATA_FORM_DATA.parameters,
-            expected_outcome: selectedItem?.payload?.expected_outcome || INITIAL_TESTDATA_FORM_DATA.expected_outcome,
-            selected_expected_outcome: INITIAL_TESTDATA_FORM_DATA.selected_expected_outcome,
+            name: initialTDName,
+            teststep: teststepId || initialTDId,
+            payload: JSON.stringify(payload?.payload || initialTDPayload),
+            parameters: payload?.parameters || initialTDParams,
+            expected_outcome: payload?.expected_outcome || initialTDExpOutcome,
+            selected_expected_outcome: initialTDSelectedExpOutcome,
         }));
     };
 
     useEffect(() => {
+        // Here ts means teststep
+        const { endpoint_id, header_id , id: teststepId, method, name: tsName, payload_id } = selectedItem;
+        const {
+            endpoint_id: initialTsEndpoint,
+            header_id: initialTsHeader,
+            id: initialTsId,
+            method: initialTsMethod,
+            name: initialTsName,
+            payload_id: initialTsPayload,
+        } = INITIAL_TESTSTEP_FORM_DATA;
+
         setTeststepFormData(p => ({
             ...p,
-            name: selectedItem?.name || INITIAL_TESTSTEP_FORM_DATA.name,
-            id: selectedItem?.id || INITIAL_TESTSTEP_FORM_DATA.id,
-            method: selectedItem?.method || INITIAL_TESTSTEP_FORM_DATA.method,
-            endpoint_id: selectedItem?.endpoint_id || INITIAL_TESTSTEP_FORM_DATA.endpoint_id,
-            header_id: selectedItem?.header_id || INITIAL_TESTSTEP_FORM_DATA.header_id,
-            payload_id: selectedItem?.payload_id || INITIAL_TESTSTEP_FORM_DATA.payload_id,
+            name: tsName || initialTsName,
+            id: teststepId || initialTsId,
+            method: method || initialTsMethod,
+            endpoint_id: endpoint_id || initialTsEndpoint,
+            header_id: header_id || initialTsHeader,
+            payload_id: payload_id || initialTsPayload,
         }));
         setInitialTestdata();
     }, [selectedItem]);

--- a/src/containers/ProjectContainer/TeststepContainer/index.jsx
+++ b/src/containers/ProjectContainer/TeststepContainer/index.jsx
@@ -3,17 +3,14 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { SubComponentsNav } from 'Components/ProjectsComponent';
 import { AddNewTeststep, TeststepViewComponent } from 'Components/ProjectsComponent/TeststepComponents';
-import {
-    addTeststepsRequest,
-    editTeststepsRequest,
-    getTeststepsRequest
-} from 'store/Teststeps/actions';
 import { addTestdataRequest, getTestdataRequest } from 'store/Testdata/actions';
+import { addTeststepsRequest, editTeststepsRequest, getTeststepsRequest } from 'store/Teststeps/actions';
 import { getEndpointsRequest } from 'store/Endpoints/actions';
 import { getHeadersRequest } from 'store/Headers/actions';
 import { getPayloadsRequest } from 'store/Payloads/actions';
+import { SubComponentsNav } from 'Components/ProjectsComponent';
+
 import {
     INITIAL_TESTSTEP_FORM_DATA,
     INITIAL_TESTDATA_FORM_DATA,
@@ -21,13 +18,13 @@ import {
 } from 'constants/appConstants';
 
 const mapState = ({ endpoints, headers, payloads, teststeps, testdata }) => ({
-    teststeps: teststeps.teststeps,
     isLoading: teststeps.isLoading,
-    testdata: testdata.testdata,
     endpoints: endpoints.endpoints,
     headers: headers.headers,
-    payloads: payloads.payloads
-})
+    payloads: payloads.payloads,
+    testdata: testdata.testdata,
+    teststeps: teststeps.teststeps,
+});
 
 const TeststepContainer = (props) => {
     let dispatch = useDispatch();
@@ -53,15 +50,15 @@ const TeststepContainer = (props) => {
     useEffect(() => {
         // get all teststeps, endpoints, headers, payloads
         dispatch(getTeststepsRequest({ project: projectName }));
-        dispatch(getEndpointsRequest({ project: projectName }))
-        dispatch(getHeadersRequest({ project: projectName }))
-        dispatch(getPayloadsRequest({ project: projectName }))
-    }, [projectName])
+        dispatch(getEndpointsRequest({ project: projectName }));
+        dispatch(getHeadersRequest({ project: projectName }));
+        dispatch(getPayloadsRequest({ project: projectName }));
+    }, [projectName]);
 
     useEffect(() => {
         setSelectedItem(teststeps.filter(e => e.id == id)[0]);
         dispatch(getTestdataRequest({ teststep: id }));
-    }, [teststeps, id])
+    }, [teststeps, id]);
 
     useEffect(() => {
         // set options to react-select format {value: "", label: ""}
@@ -70,52 +67,52 @@ const TeststepContainer = (props) => {
         let payloads_data = [];
 
         endpoints.forEach(ele => {
-            endpoints_data.push({ value: ele.id, label: ele.name })
-        })
+            endpoints_data.push({ value: ele.id, label: ele.name });
+        });
         headers.forEach(ele => {
-            headers_data.push({ value: ele.id, label: ele.name })
-        })
+            headers_data.push({ value: ele.id, label: ele.name });
+        });
         payloads.forEach(ele => {
-            payloads_data.push({ value: ele.id, label: ele.name })
-        })
+            payloads_data.push({ value: ele.id, label: ele.name });
+        });
 
         setOptions(p => ({
             ...p,
             endpoints: endpoints_data,
             headers: headers_data,
-            payloads: payloads_data
-        }))
-    }, [endpoints, headers, payloads])
+            payloads: payloads_data,
+        }));
+    }, [endpoints, headers, payloads]);
 
     const handleFormDataChange = (key, value) => {
         // Accepts key, value
         setTeststepFormData(p => ({
             ...p,
-            [key]: value
-        }))
-    }
+            [key]: value,
+        }));
+    };
 
     const handleTeststepFormSubmit = (e) => {
         // submit the form
         e.preventDefault();
         if (cat === 'add') {
-            dispatch(addTeststepsRequest(teststepFormData))
+            dispatch(addTeststepsRequest(teststepFormData));
         } else {
-            dispatch(editTeststepsRequest(teststepFormData))
+            dispatch(editTeststepsRequest(teststepFormData));
         }
-    }
+    };
 
     const setInitialTestdata = () => {
         setTestdataFormData(p => ({
             ...p,
-            name: INITIAL_TESTDATA_FORM_DATA.expected_outcome,
-            teststep: selectedItem?.id || INITIAL_TESTDATA_FORM_DATA.id,
+            name: INITIAL_TESTDATA_FORM_DATA.name,
+            teststep: selectedItem?.id || INITIAL_TESTDATA_FORM_DATA.teststep,
             payload: JSON.stringify(selectedItem?.payload?.payload || INITIAL_TESTDATA_FORM_DATA.payload),
             parameters: selectedItem?.payload?.parameters || INITIAL_TESTDATA_FORM_DATA.parameters,
             expected_outcome: selectedItem?.payload?.expected_outcome || INITIAL_TESTDATA_FORM_DATA.expected_outcome,
-            selected_expected_outcome: INITIAL_TESTDATA_FORM_DATA.selected_expected_outcome
-        }))
-    }
+            selected_expected_outcome: INITIAL_TESTDATA_FORM_DATA.selected_expected_outcome,
+        }));
+    };
 
     useEffect(() => {
         setTeststepFormData(p => ({
@@ -125,22 +122,22 @@ const TeststepContainer = (props) => {
             method: selectedItem?.method || INITIAL_TESTSTEP_FORM_DATA.method,
             endpoint_id: selectedItem?.endpoint_id || INITIAL_TESTSTEP_FORM_DATA.endpoint_id,
             header_id: selectedItem?.header_id || INITIAL_TESTSTEP_FORM_DATA.header_id,
-            payload_id: selectedItem?.payload_id || INITIAL_TESTSTEP_FORM_DATA.payload_id
-        }))
+            payload_id: selectedItem?.payload_id || INITIAL_TESTSTEP_FORM_DATA.payload_id,
+        }));
         setInitialTestdata();
-    }, [selectedItem])
+    }, [selectedItem]);
 
     const toggleAddTestdataForm = () => {
         setShowAddTestdataForm(!showAddTestdataForm);
         setInitialTestdata();
-    }
+    };
 
     const handleTestdataFormChange = (key, value) => {
         setTestdataFormData(p => ({
             ...p,
             [key]: value
-        }))
-    }
+        }));
+    };
 
     const handleTestdataFormSubmit = (e) => {
         e.preventDefault();
@@ -152,7 +149,7 @@ const TeststepContainer = (props) => {
         delete submitData.selected_expected_outcome;
         dispatch(addTestdataRequest(submitData));
         toggleAddTestdataForm();
-    }
+    };
 
     return (
         <>
@@ -189,8 +186,8 @@ const TeststepContainer = (props) => {
     )
 }
 
-export default TeststepContainer;
-
 TeststepContainer.propTypes = {
     cat: PropTypes.oneOf(["add", "edit"])
-}
+};
+
+export default TeststepContainer;

--- a/src/containers/ProjectContainer/TeststepContainer/index.jsx
+++ b/src/containers/ProjectContainer/TeststepContainer/index.jsx
@@ -5,19 +5,19 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { SubComponentsNav } from 'Components/ProjectsComponent';
 import { AddNewTeststep, TeststepViewComponent } from 'Components/ProjectsComponent/TeststepComponents';
-import { 
-    addTeststepsRequest, 
-    editTeststepsRequest, 
-    getTeststepsRequest 
+import {
+    addTeststepsRequest,
+    editTeststepsRequest,
+    getTeststepsRequest
 } from 'store/Teststeps/actions';
 import { addTestdataRequest, getTestdataRequest } from 'store/Testdata/actions';
 import { getEndpointsRequest } from 'store/Endpoints/actions';
 import { getHeadersRequest } from 'store/Headers/actions';
 import { getPayloadsRequest } from 'store/Payloads/actions';
-import { 
+import {
     INITIAL_TESTSTEP_FORM_DATA,
-    INITIAL_TESTDATA_FORM_DATA, 
-    SELECT_OPTIONS_TESTDATA_FORM 
+    INITIAL_TESTDATA_FORM_DATA,
+    SELECT_OPTIONS_TESTDATA_FORM
 } from 'constants/appConstants';
 
 const mapState = ({ endpoints, headers, payloads, teststeps, testdata }) => ({
@@ -35,13 +35,13 @@ const TeststepContainer = (props) => {
 
     const { cat } = props;
     const { projectName, id } = useParams();
-    const { 
-        endpoints, 
-        headers, 
-        payloads, 
+    const {
+        endpoints,
+        headers,
+        payloads,
         teststeps,
-        isLoading, 
-        testdata 
+        isLoading,
+        testdata
     } = useSelector(mapState);
 
     const [selectedItem, setSelectedItem] = useState({});
@@ -52,17 +52,17 @@ const TeststepContainer = (props) => {
 
     useEffect(() => {
         // get all teststeps, endpoints, headers, payloads
-        dispatch(getTeststepsRequest({project: projectName}));
-        dispatch(getEndpointsRequest({project: projectName}))
-        dispatch(getHeadersRequest({project: projectName}))
-        dispatch(getPayloadsRequest({project: projectName}))
+        dispatch(getTeststepsRequest({ project: projectName }));
+        dispatch(getEndpointsRequest({ project: projectName }))
+        dispatch(getHeadersRequest({ project: projectName }))
+        dispatch(getPayloadsRequest({ project: projectName }))
     }, [projectName])
 
     useEffect(() => {
-        setSelectedItem(teststeps.filter(e => e.id==id)[0]);
-        dispatch(getTestdataRequest({teststep: id}));
+        setSelectedItem(teststeps.filter(e => e.id == id)[0]);
+        dispatch(getTestdataRequest({ teststep: id }));
     }, [teststeps, id])
-    
+
     useEffect(() => {
         // set options to react-select format {value: "", label: ""}
         let endpoints_data = [];
@@ -70,19 +70,19 @@ const TeststepContainer = (props) => {
         let payloads_data = [];
 
         endpoints.forEach(ele => {
-            endpoints_data.push({value: ele.id, label: ele.name})
+            endpoints_data.push({ value: ele.id, label: ele.name })
         })
         headers.forEach(ele => {
-            headers_data.push({value: ele.id, label: ele.name})
+            headers_data.push({ value: ele.id, label: ele.name })
         })
         payloads.forEach(ele => {
-            payloads_data.push({value: ele.id, label: ele.name})
+            payloads_data.push({ value: ele.id, label: ele.name })
         })
 
         setOptions(p => ({
-            ...p, 
-            endpoints: endpoints_data, 
-            headers: headers_data, 
+            ...p,
+            endpoints: endpoints_data,
+            headers: headers_data,
             payloads: payloads_data
         }))
     }, [endpoints, headers, payloads])
@@ -98,11 +98,23 @@ const TeststepContainer = (props) => {
     const handleTeststepFormSubmit = (e) => {
         // submit the form
         e.preventDefault();
-        if(cat==='add') {
+        if (cat === 'add') {
             dispatch(addTeststepsRequest(teststepFormData))
         } else {
             dispatch(editTeststepsRequest(teststepFormData))
         }
+    }
+
+    const setInitialTestdata = () => {
+        setTestdataFormData(p => ({
+            ...p,
+            name: INITIAL_TESTDATA_FORM_DATA.expected_outcome,
+            teststep: selectedItem?.id || INITIAL_TESTDATA_FORM_DATA.id,
+            payload: JSON.stringify(selectedItem?.payload?.payload || INITIAL_TESTDATA_FORM_DATA.payload),
+            parameters: selectedItem?.payload?.parameters || INITIAL_TESTDATA_FORM_DATA.parameters,
+            expected_outcome: selectedItem?.payload?.expected_outcome || INITIAL_TESTDATA_FORM_DATA.expected_outcome,
+            selected_expected_outcome: INITIAL_TESTDATA_FORM_DATA.selected_expected_outcome
+        }))
     }
 
     useEffect(() => {
@@ -115,10 +127,12 @@ const TeststepContainer = (props) => {
             header_id: selectedItem?.header_id || INITIAL_TESTSTEP_FORM_DATA.header_id,
             payload_id: selectedItem?.payload_id || INITIAL_TESTSTEP_FORM_DATA.payload_id
         }))
+        setInitialTestdata();
     }, [selectedItem])
-    
+
     const toggleAddTestdataForm = () => {
         setShowAddTestdataForm(!showAddTestdataForm);
+        setInitialTestdata();
     }
 
     const handleTestdataFormChange = (key, value) => {
@@ -140,29 +154,17 @@ const TeststepContainer = (props) => {
         toggleAddTestdataForm();
     }
 
-    useEffect(() => {
-        setTestdataFormData(p => ({
-            ...p,
-            teststep: selectedItem?.id || INITIAL_TESTDATA_FORM_DATA.id,
-            payload: JSON.stringify(selectedItem?.payload?.payload || INITIAL_TESTDATA_FORM_DATA.payload),
-            parameters: selectedItem?.payload?.parameters || INITIAL_TESTDATA_FORM_DATA.parameters,
-            expected_outcome: selectedItem?.payload?.expected_outcome || INITIAL_TESTDATA_FORM_DATA.expected_outcome
-        }))
-    }, [selectedItem])
-    
-    
-
     return (
         <>
-            <SubComponentsNav 
+            <SubComponentsNav
                 title="Teststeps"
                 data={teststeps}
                 isLoading={isLoading}
                 onAddBtnClick={() => navigate(`/project/${projectName}/teststeps/new`)}
                 onSelectItemUrl={`/project/${projectName}/teststeps`}
             />
-            {cat?(
-                <AddNewTeststep 
+            {cat ? (
+                <AddNewTeststep
                     cat={cat}
                     isLoading={isLoading}
                     data={teststepFormData}
@@ -170,8 +172,8 @@ const TeststepContainer = (props) => {
                     options={options}
                     handleSubmit={handleTeststepFormSubmit}
                 />
-            ):(
-                <TeststepViewComponent 
+            ) : (
+                <TeststepViewComponent
                     isLoading={isLoading}
                     data={selectedItem}
                     projectName={projectName}

--- a/src/store/Testdata/sagas.js
+++ b/src/store/Testdata/sagas.js
@@ -1,8 +1,10 @@
 import { call, put, takeLatest } from 'redux-saga/effects';
-import { getTestdataSuccess } from './actions';
-import { addTestdataApi, getTestdatasApi } from './apis';
-import testdataConstants from './constants';
 import { toast } from 'react-toastify';
+
+import { addTestdataApi, getTestdatasApi } from './apis';
+import { getTestdataSuccess } from './actions';
+
+import testdataConstants from './constants';
 
 
 export function* getTestdatas({ payload }) {

--- a/src/store/Testdata/sagas.js
+++ b/src/store/Testdata/sagas.js
@@ -18,7 +18,7 @@ export function* addTestdata({ payload }) {
     try {
         yield call(addTestdataApi, payload);
         toast.success("Testdata Added Successfully!")
-        yield call(getTestdatas, {payload: { testcase: payload.testcase }});
+        yield call(getTestdatas, {payload: { teststep: payload.teststep }});
     } catch (error) {
         toast.error(error.data.error)
     }


### PR DESCRIPTION
Fix new testdata page bug

**Summary**:
Once a user fills the required fields of payload and the expected outcome in creating testdata, the page until and unless refreshed does not show the added testdata, which gets saved after clicking on the "save" button. The page shows the added testdata after a hard refresh. 
This pull request solves this bug.

**Ticket Link**
https://trello.com/c/VGkyCzKi/40-fix-new-testdata-page-bug

**Solution**
Before:

[before.webm](https://user-images.githubusercontent.com/72058456/196090548-fa602118-e963-4952-929b-54a6ef77dbba.webm)

After:

[after.webm](https://user-images.githubusercontent.com/72058456/196090560-0e070ec8-278f-4f24-8b60-1d37c143d1e5.webm)
