### PR TITLE
fix/63 after logout redirect bug

### DIFF
--- a/src/store/User/reducers.js
+++ b/src/store/User/reducers.js
@@ -4,100 +4,100 @@ import userConstants from "./constants";
 
 const isTokenExist = getLocalStorage("accessToken") ? true : false;
 
-const INITIAL_STATE = {
-    isLoggedIn: isTokenExist,
-    isLoading: false,
-    currentUser: {},
-    userErr: [],
-    error: [],
+const initialState = {
+  isLoggedIn: isTokenExist,
+  isLoading: false,
+  currentUser: {},
+  userErr: [],
+  error: [],
 };
 
-const GET_USERS_INITIAL_STATE = { isLoading: true, users: [], errors: [] };
+const getUsersInitialState = { isLoading: true, users: [], errors: [] };
 
-const userReducer = (state = INITIAL_STATE, action) => {
-    switch (action.type) {
-        case userConstants.SIGN_IN_REQUEST:
-            return { ...state, isLoading: true };
+const userReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case userConstants.SIGN_IN_REQUEST:
+      return { ...state, isLoading: true };
 
-        case userConstants.SIGN_IN_SUCCESS:
-            return {
-                ...state,
-                isLoading: false,
-                isLoggedIn: true,
-                currentUser: action.payload,
-                userErr: [],
-            };
+    case userConstants.SIGN_IN_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        isLoggedIn: true,
+        currentUser: action.payload,
+        userErr: [],
+      };
 
-        case userConstants.SIGN_IN_FAILURE:
-            return { ...state, isLoading: false, userErr: action.payload };
+    case userConstants.SIGN_IN_FAILURE:
+      return { ...state, isLoading: false, userErr: action.payload };
 
-        case userConstants.SIGN_UP_REQUEST:
-            return { ...state, isLoading: true };
+    case userConstants.SIGN_UP_REQUEST:
+      return { ...state, isLoading: true };
 
-        case userConstants.SIGN_UP_SUCCESS:
-            return { ...state, isLoading: false };
+    case userConstants.SIGN_UP_SUCCESS:
+      return { ...state, isLoading: false };
 
-        case userConstants.SIGN_UP_FAILURE:
-            return { ...state, isLoading: false, userErr: action.payload };
+    case userConstants.SIGN_UP_FAILURE:
+      return { ...state, isLoading: false, userErr: action.payload };
 
-        case userConstants.SIGN_OUT_SUCCESS:
-            return {
-                ...state,
-                isLoggedIn: false,
-                currentUser: null,
-                userErr: [],
-            };
+    case userConstants.SIGN_OUT_SUCCESS:
+      return {
+        ...state,
+        isLoggedIn: false,
+        currentUser: {},
+        userErr: [],
+      };
 
-        case userConstants.GET_CURRENT_USER_INFO_REQUEST:
-            return { ...state, isLoading: true };
+    case userConstants.GET_CURRENT_USER_INFO_REQUEST:
+      return { ...state, isLoading: true };
 
-        case userConstants.GET_CURRENT_USER_INFO_SUCCESS:
-            return {
-                ...state,
-                currentUser: action.payload,
-                userErr: [],
-                isLoading: false,
-            };
+    case userConstants.GET_CURRENT_USER_INFO_SUCCESS:
+      return {
+        ...state,
+        currentUser: action.payload,
+        userErr: [],
+        isLoading: false,
+      };
 
-        case userConstants.GET_CURRENT_USER_INFO_FAILURE:
-            return { ...state, userErr: action.payload, isLoading: false };
+    case userConstants.GET_CURRENT_USER_INFO_FAILURE:
+      return { ...state, userErr: action.payload, isLoading: false };
 
-        case userConstants.UPDATE_USER_PROFILE_REQUEST:
-            return { ...state, isLoading: true };
+    case userConstants.UPDATE_USER_PROFILE_REQUEST:
+      return { ...state, isLoading: true };
 
-        case userConstants.UPDATE_USER_PROFILE_SUCCESS:
-            return { ...state, currentUser: action.payload, isLoading: false };
+    case userConstants.UPDATE_USER_PROFILE_SUCCESS:
+      return { ...state, currentUser: action.payload, isLoading: false };
 
-        case userConstants.UPDATE_USER_PROFILE_FAILURE:
-            return { ...state, isLoading: false };
+    case userConstants.UPDATE_USER_PROFILE_FAILURE:
+      return { ...state, isLoading: false };
 
-        case userConstants.CHANGE_USER_PASSWORD_REQUEST:
-            return { ...state, isLoading: true };
+    case userConstants.CHANGE_USER_PASSWORD_REQUEST:
+      return { ...state, isLoading: true };
 
-        case userConstants.CHANGE_USER_PASSWORD_SUCCESS:
-            return { ...state, isLoading: false };
+    case userConstants.CHANGE_USER_PASSWORD_SUCCESS:
+      return { ...state, isLoading: false };
 
-        case userConstants.CHANGE_USER_PASSWORD_FAILURE:
-            return { ...state, isLoading: false };
+    case userConstants.CHANGE_USER_PASSWORD_FAILURE:
+      return { ...state, isLoading: false };
 
-        default:
-            return state;
-    }
+    default:
+      return state;
+  }
 };
 
-const getUsersReducer = (state = GET_USERS_INITIAL_STATE, action) => {
-    switch (action.type) {
-        case userConstants.GET_ALL_USERS_SUCCESS:
-            return {
-                ...state,
-                isLoading: false,
-                users: action.payload,
-                errors: [],
-            };
+const getUsersReducer = (state = getUsersInitialState, action) => {
+  switch (action.type) {
+    case userConstants.GET_ALL_USERS_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        users: action.payload,
+        errors: [],
+      };
 
-        default:
-            return state;
-    }
+    default:
+      return state;
+  }
 };
 
 export { getUsersReducer, userReducer };


### PR DESCRIPTION
fix after logout redirection by changing the currentUser value to an empty object in users reducers.

**Ticket Link:**
https://trello.com/c/8zfWHXCW/63-logout-redirect-bug

**Summary**
Earlier, the user clicked the logout button to end the session, then instead of navigating to the login screen, the same route showed a blank screen. This happens because the `currentUser` field is set to `null` in the reducer of User which affects the destructuring of the currentUser object, the code breaks, and a blank screen appears in the UI. 
To avoid a blank screen and navigate to the login screen when logout hits, the `currentUser` is set to be an empty object instead of a `null`, by which destructuring of the currentUser object is done which can be handled and navigate to the login screen.
